### PR TITLE
Update ngx-leaflet-locate.component.ts

### DIFF
--- a/src/lib/ngx-leaflet-locate.component.ts
+++ b/src/lib/ngx-leaflet-locate.component.ts
@@ -20,7 +20,10 @@ export class NgxLeafletLocateComponent implements OnInit, OnDestroy {
   };
 
   ngOnDestroy() {
-    if (this.control && this.map) this.control.stop()
+    if (this.control && this.map) {
+      this.control.stop();
+      this._map.off("unload", this.control._unload, this.control);
+    }
     if (this._map && this.control) this._map.removeControl(this.control);
     this._map?.off('locationfound')
   };


### PR DESCRIPTION
prevent unload event to fail, cause the map instance is already removed https://github.com/runette/ngx-leaflet-locate/issues/4